### PR TITLE
Improve subscription modal UI

### DIFF
--- a/app/(public)/components/get-subscription-modal.tsx
+++ b/app/(public)/components/get-subscription-modal.tsx
@@ -1,4 +1,5 @@
-import { ArrowSquareOut } from "@phosphor-icons/react/dist/ssr";
+"use client";
+import { ArrowSquareOut, Check } from "@phosphor-icons/react/dist/ssr";
 import React from "react";
 
 import { Button } from "@/components/button";
@@ -7,25 +8,40 @@ import { useSubscription } from "@/lib/auth-client";
 import Modal from "../../../components/modal";
 
 export default function GetSubscriptionModal({
-  isOpen,
   close,
   message,
 }: {
-  isOpen: boolean;
   close: () => void;
   message?: string;
 }) {
   const [sub] = useSubscription();
   return (
-    <Modal title={"Get Sociocube plus"} close={close} open={isOpen}>
-      <div>{message}</div>
+    <Modal title={"Get Sociocube plus"} close={close} open={!!message}>
+      {message ? <p className="text-center text-sm text-gray-700">{message}</p> : null}
       {!sub?.existing.plan && (
-        <div className="space-y-2 py-9">
-          <p className="text-center">Get Plus for 20$</p>
+        <div className="space-y-6 py-9">
+          <ul className="space-y-2 text-sm text-gray-700">
+            <li className="flex items-start gap-2">
+              <Check className="text-primary" weight="bold" />
+              10 AI searches per day
+            </li>
+            <li className="flex items-start gap-2">
+              <Check className="text-primary" weight="bold" />
+              20 creators per search
+            </li>
+            <li className="flex items-start gap-2">
+              <Check className="text-primary" weight="bold" />
+              View contact details
+            </li>
+            <li className="flex items-start gap-2">
+              <Check className="text-primary" weight="bold" />
+              Download applicant data
+            </li>
+          </ul>
           {sub?.link && (
             <a href={sub.link}>
               <Button className="mx-auto flex items-center gap-2">
-                Purchase now <ArrowSquareOut weight="bold" />
+                Start 7-day free trial <ArrowSquareOut weight="bold" />
               </Button>
             </a>
           )}

--- a/lib/auth-client.tsx
+++ b/lib/auth-client.tsx
@@ -98,7 +98,6 @@ export function GlobalStateWrapper({ children }: PropsWithChildren) {
       <GetSubscriptionModal
         message={showSubscribeModal}
         close={() => setShowSubscribeModal(undefined)}
-        isOpen={!!showSubscribeModal}
       />
       <Suspense>
         <ProgressLoader color="#5b9364" showSpinner={false} />


### PR DESCRIPTION
## Summary
- enhance Subscription modal with premium features list and buy button
- convert modal to client component
- use message truthiness to control modal open state
- change CTA to "Start 7-day free trial"

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842aa6c37088330ba0e2e9dd5634f93