### PR TITLE
Fix usage of Array.toReversed

### DIFF
--- a/app/(dashboard)/inbox/[username]/components/chat-window.tsx
+++ b/app/(dashboard)/inbox/[username]/components/chat-window.tsx
@@ -35,7 +35,7 @@ export default function ChatWindow({
       loading?: boolean;
       failed?: boolean;
     })[]
-  >(chat.messages.toReversed());
+  >(chat.messages.slice().reverse());
 
   function onSubmit(data: FormValues) {
     if (!user || !data.text) return;

--- a/constants/age.ts
+++ b/constants/age.ts
@@ -29,7 +29,7 @@ export const AGE_RANGES = [
 
 export function getAgeRange(d: Date) {
   const age = getAge(d);
-  for (const range of AGE_RANGES.toReversed()) {
+  for (const range of [...AGE_RANGES].reverse()) {
     if (age >= range.minimum && age <= range.maximum) return range;
   }
   return AGE_RANGES[0];


### PR DESCRIPTION
## Summary
- improve browser compatibility by replacing `Array.toReversed` with `.slice().reverse()`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cypress missing)*

------
https://chatgpt.com/codex/tasks/task_e_684039cb0ba483308288043fd17d2668